### PR TITLE
feat: replace fences with comment blocks when language explicitly set to none

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build Status](https://travis-ci.org/campoy/embedmd.svg)](https://travis-ci.org/campoy/embedmd) [![Go Report Card](https://goreportcard.com/badge/github.com/campoy/embedmd)](https://goreportcard.com/report/github.com/campoy/embedmd)
-
-
 # embedmd
+
+[![Build Status](https://travis-ci.org/seanblong/embedmd.svg)](https://travis-ci.org/seanblong/embedmd)
+[![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/embedmd)](https://goreportcard.com/report/github.com/seanblong/embedmd)
 
 Are you tired of copy pasting your code into your `README.md` file, just to
 forget about it later on and have unsynced copies? Or even worse, code
@@ -68,6 +68,14 @@ files, since `.go` matches `go`). However, this will fail with other files like
 [embedmd]:# (file.ext)
 ```
 
+If you want to remove code fencing altogether, you can explicitly use `none` as
+the language.  This can be useful when composing large, renderd Markdown files out
+of smaller Markdown files that contain fenced code blocks themselves.
+
+```Markdown
+[embedmd]:# (file.md none)
+```
+
 ## Installation
 
 > You can install Go by following [these instructions](https://golang.org/doc/install).
@@ -75,23 +83,21 @@ files, since `.go` matches `go`). However, this will fail with other files like
 `embedmd` is written in Go, so if you have Go installed you can install it with
 `go get`:
 
-```
-go get github.com/campoy/embedmd
+```bash
+go install github.com/seanblong/embedmd
 ```
 
 This will download the code, compile it, and leave an `embedmd` binary
 in `$GOPATH/bin`.
 
-Eventually, and if there's enough interest, I will provide binaries for
-every OS and architecture out there ... _eventually_.
-
-## Usage:
+## Usage
 
 Given the two files in [sample](sample):
 
 *hello.go:*
 
 [embedmd]:# (sample/hello.go)
+
 ```go
 // Copyright 2016 Google Inc. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
@@ -100,18 +106,19 @@ Given the two files in [sample](sample):
 package main
 
 import (
-	"fmt"
-	"time"
+    "fmt"
+    "time"
 )
 
 func main() {
-	fmt.Println("Hello, there, it is", time.Now())
+    fmt.Println("Hello, there, it is", time.Now())
 }
 ```
 
 *docs.md:*
 
 [embedmd]:# (sample/docs.md Markdown /./ /embedmd.*time.*/)
+
 ```Markdown
 # A hello world in Go
 
@@ -136,15 +143,15 @@ You can also see how to get the current time:
 [embedmd]:# (hello.go /time\.[^)]*\)/)
 ```
 
-# Flags
+## Flags
 
 * `-w`: Executing `embedmd -w docs.md` will modify `docs.md`
-and add the corresponding code snippets, as shown in
-[sample/result.md](sample/result.md).
+  and add the corresponding code snippets, as shown in
+  [sample/result.md](sample/result.md).
 
 * `-d`: Executing `embedmd -d docs.md` will display the difference
-between the contents of `docs.md` and the output of
-`embedmd docs.md`.
+  between the contents of `docs.md` and the output of
+  `embedmd docs.md`.
 
 ### Disclaimer
 

--- a/embedmd/command.go
+++ b/embedmd/command.go
@@ -22,6 +22,7 @@ import (
 type command struct {
 	path, lang string
 	start, end *string
+	useFence   bool
 }
 
 func parseCommand(s string) (*command, error) {
@@ -49,6 +50,10 @@ func parseCommand(s string) (*command, error) {
 		}
 		cmd.lang = ext[1:]
 	}
+
+	// When language is explicitly set to "none" we won't use fences, otherwise
+	// fence block will be used with specified or inferred language.
+	cmd.useFence = cmd.lang != "none"
 
 	switch {
 	case len(args) == 1:

--- a/embedmd/command_test.go
+++ b/embedmd/command_test.go
@@ -69,6 +69,9 @@ func TestParseCommand(t *testing.T) {
 		{name: "bad url",
 			in:  "(http://golang:org:sample.go)",
 			cmd: command{path: "http://golang:org:sample.go", lang: "go"}},
+		{name: "file language none (no fencing)",
+			in:  "(test.md none)",
+			cmd: command{path: "test.md", lang: "none"}},
 	}
 
 	for _, tt := range tc {

--- a/embedmd/embedmd.go
+++ b/embedmd/embedmd.go
@@ -104,10 +104,12 @@ func (e *embedder) runCommand(w io.Writer, cmd *command) error {
 	}
 
 	if cmd.useFence {
+		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "```"+cmd.lang)
 		w.Write(b)
 		fmt.Fprintln(w, "```")
 	} else {
+		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "<!-- embedmd block start -->")
 		w.Write(b)
 		fmt.Fprintln(w, "<!-- embedmd block end -->")

--- a/embedmd/embedmd.go
+++ b/embedmd/embedmd.go
@@ -16,7 +16,7 @@
 //
 // The format of an embedmd command is:
 //
-//     [embedmd]:# (pathOrURL language /start regexp/ /end regexp/)
+//	[embedmd]:# (pathOrURL language /start regexp/ /end regexp/)
 //
 // The embedded code will be extracted from the file at pathOrURL,
 // which can either be a relative path to a file in the local file
@@ -29,27 +29,26 @@
 // Omitting the the second regular expression will embed only the piece of
 // text that matches /regexp/:
 //
-//     [embedmd]:# (pathOrURL language /regexp/)
+//	[embedmd]:# (pathOrURL language /regexp/)
 //
 // To embed the whole line matching a regular expression you can use:
 //
-//     [embedmd]:# (pathOrURL language /.*regexp.*\n/)
+//	[embedmd]:# (pathOrURL language /.*regexp.*\n/)
 //
 // If you want to embed from a point to the end you should use:
 //
-//     [embedmd]:# (pathOrURL language /start regexp/ $)
+//	[embedmd]:# (pathOrURL language /start regexp/ $)
 //
 // Finally you can embed a whole file by omitting both regular expressions:
 //
-//     [embedmd]:# (pathOrURL language)
+//	[embedmd]:# (pathOrURL language)
 //
 // You can ommit the language in any of the previous commands, and the extension
 // of the file will be used for the snippet syntax highlighting. Note that while
 // this works Go files, since the file extension .go matches the name of the language
 // go, this will fail with other files like .md whose language name is markdown.
 //
-//     [embedmd]:# (file.ext)
-//
+//	[embedmd]:# (file.ext)
 package embedmd
 
 import (
@@ -92,21 +91,27 @@ type embedder struct {
 func (e *embedder) runCommand(w io.Writer, cmd *command) error {
 	b, err := e.Fetch(e.baseDir, cmd.path)
 	if err != nil {
-		return fmt.Errorf("could not read %s: %v", cmd.path, err)
+		return fmt.Errorf("could not read %s: %w", cmd.path, err)
 	}
 
 	b, err = extract(b, cmd.start, cmd.end)
 	if err != nil {
-		return fmt.Errorf("could not extract content from %s: %v", cmd.path, err)
+		return fmt.Errorf("could not extract content from %s: %w", cmd.path, err)
 	}
 
 	if len(b) > 0 && b[len(b)-1] != '\n' {
 		b = append(b, '\n')
 	}
 
-	fmt.Fprintln(w, "```"+cmd.lang)
-	w.Write(b)
-	fmt.Fprintln(w, "```")
+	if cmd.useFence {
+		fmt.Fprintln(w, "```"+cmd.lang)
+		w.Write(b)
+		fmt.Fprintln(w, "```")
+	} else {
+		fmt.Fprintln(w, "<!-- embedmd block start -->")
+		w.Write(b)
+		fmt.Fprintln(w, "<!-- embedmd block end -->")
+	}
 	return nil
 }
 

--- a/embedmd/embedmd_test.go
+++ b/embedmd/embedmd_test.go
@@ -96,20 +96,20 @@ func TestExtractFromFile(t *testing.T) {
 			name:  "extract the whole file",
 			cmd:   command{path: "code.go", lang: "go", useFence: true},
 			files: map[string][]byte{"code.go": []byte(content)},
-			out:   "```go\n" + string(content) + "```\n",
+			out:   "\n```go\n" + string(content) + "```\n",
 		},
 		{
 			name:    "extract the whole from a different directory",
 			cmd:     command{path: "code.go", lang: "go", useFence: true},
 			baseDir: "sample",
 			files:   map[string][]byte{"sample/code.go": []byte(content)},
-			out:     "```go\n" + string(content) + "```\n",
+			out:     "\n```go\n" + string(content) + "```\n",
 		},
 		{
 			name:  "added line break",
 			cmd:   command{path: "code.go", lang: "go", useFence: true, start: ptr("/fmt\\.Println/")},
 			files: map[string][]byte{"code.go": []byte(content)},
-			out:   "```go\nfmt.Println\n```\n",
+			out:   "\n```go\nfmt.Println\n```\n",
 		},
 		{
 			name: "missing file",
@@ -126,7 +126,7 @@ func TestExtractFromFile(t *testing.T) {
 			name:  "no fencing",
 			cmd:   command{path: "code.go", lang: "none"},
 			files: map[string][]byte{"code.go": []byte(content)},
-			out:   "<!-- embedmd block start -->\n" + string(content) + "<!-- embedmd block end -->\n",
+			out:   "\n<!-- embedmd block start -->\n" + string(content) + "<!-- embedmd block end -->\n",
 		},
 	}
 
@@ -183,7 +183,7 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 			files: map[string][]byte{"code.go": []byte(content)},
 			out: "# This is some markdown\n" +
-				"[embedmd]:# (code.go)\n" +
+				"[embedmd]:# (code.go)\n\n" +
 				"```go\n" +
 				string(content) +
 				"```\n" +
@@ -196,7 +196,7 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 			files: map[string][]byte{"code.go": []byte(content)},
 			out: "# This is some markdown\n" +
-				"[embedmd]:# (code.go none)\n" +
+				"[embedmd]:# (code.go none)\n\n" +
 				"<!-- embedmd block start -->\n" +
 				string(content) +
 				"<!-- embedmd block end -->\n" +
@@ -210,7 +210,7 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 			files: map[string][]byte{"sample/code.go": []byte(content)},
 			out: "# This is some markdown\n" +
-				"[embedmd]:# (code.go)\n" +
+				"[embedmd]:# (code.go)\n\n" +
 				"```go\n" +
 				string(content) +
 				"```\n" +
@@ -226,7 +226,7 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 			files: map[string][]byte{"code.go": []byte(content)},
 			out: "# This is some markdown\n" +
-				"[embedmd]:# (code.go)\n" +
+				"[embedmd]:# (code.go)\n\n" +
 				"```go\n" +
 				string(content) +
 				"```\n" +
@@ -242,7 +242,7 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 			files: map[string][]byte{"code.go": []byte(content)},
 			out: "# This is some markdown\n" +
-				"[embedmd]:# (code.go none)\n" +
+				"[embedmd]:# (code.go none)\n\n" +
 				"<!-- embedmd block start -->\n" +
 				string(content) +
 				"<!-- embedmd block end -->\n" +
@@ -255,7 +255,7 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 			urls: map[string][]byte{"https://fakeurl.com/main.go": []byte(content)},
 			out: "# This is some markdown\n" +
-				"[embedmd]:# (https://fakeurl.com/main.go)\n" +
+				"[embedmd]:# (https://fakeurl.com/main.go)\n\n" +
 				"```go\n" +
 				string(content) +
 				"```\n" +

--- a/embedmd/embedmd_test.go
+++ b/embedmd/embedmd_test.go
@@ -94,33 +94,39 @@ func TestExtractFromFile(t *testing.T) {
 	}{
 		{
 			name:  "extract the whole file",
-			cmd:   command{path: "code.go", lang: "go"},
+			cmd:   command{path: "code.go", lang: "go", useFence: true},
 			files: map[string][]byte{"code.go": []byte(content)},
 			out:   "```go\n" + string(content) + "```\n",
 		},
 		{
 			name:    "extract the whole from a different directory",
-			cmd:     command{path: "code.go", lang: "go"},
+			cmd:     command{path: "code.go", lang: "go", useFence: true},
 			baseDir: "sample",
 			files:   map[string][]byte{"sample/code.go": []byte(content)},
 			out:     "```go\n" + string(content) + "```\n",
 		},
 		{
 			name:  "added line break",
-			cmd:   command{path: "code.go", lang: "go", start: ptr("/fmt\\.Println/")},
+			cmd:   command{path: "code.go", lang: "go", useFence: true, start: ptr("/fmt\\.Println/")},
 			files: map[string][]byte{"code.go": []byte(content)},
 			out:   "```go\nfmt.Println\n```\n",
 		},
 		{
 			name: "missing file",
-			cmd:  command{path: "code.go", lang: "go"},
+			cmd:  command{path: "code.go", lang: "go", useFence: true},
 			err:  "could not read code.go: file does not exist",
 		},
 		{
 			name:  "unmatched regexp",
-			cmd:   command{path: "code.go", lang: "go", start: ptr("/potato/")},
+			cmd:   command{path: "code.go", lang: "go", useFence: true, start: ptr("/potato/")},
 			files: map[string][]byte{"code.go": []byte(content)},
 			err:   "could not extract content from code.go: could not match \"/potato/\"",
+		},
+		{
+			name:  "no fencing",
+			cmd:   command{path: "code.go", lang: "none"},
+			files: map[string][]byte{"code.go": []byte(content)},
+			out:   "<!-- embedmd block start -->\n" + string(content) + "<!-- embedmd block end -->\n",
 		},
 	}
 
@@ -184,6 +190,19 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 		},
 		{
+			name: "generating code for first time (no fencing)",
+			in: "# This is some markdown\n" +
+				"[embedmd]:# (code.go none)\n" +
+				"Yay!\n",
+			files: map[string][]byte{"code.go": []byte(content)},
+			out: "# This is some markdown\n" +
+				"[embedmd]:# (code.go none)\n" +
+				"<!-- embedmd block start -->\n" +
+				string(content) +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+		},
+		{
 			name: "generating code for first time with base dir",
 			dir:  "sample",
 			in: "# This is some markdown\n" +
@@ -214,6 +233,22 @@ func TestProcess(t *testing.T) {
 				"Yay!\n",
 		},
 		{
+			name: "replacing existing code (no fencing)",
+			in: "# This is some markdown\n" +
+				"[embedmd]:# (code.go none)\n" +
+				"<!-- embedmd block start -->\n" +
+				string(content) +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+			files: map[string][]byte{"code.go": []byte(content)},
+			out: "# This is some markdown\n" +
+				"[embedmd]:# (code.go none)\n" +
+				"<!-- embedmd block start -->\n" +
+				string(content) +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+		},
+		{
 			name: "embedding code from a URL",
 			in: "# This is some markdown\n" +
 				"[embedmd]:# (https://fakeurl.com/main.go)\n" +
@@ -238,7 +273,7 @@ func TestProcess(t *testing.T) {
 			in: "# This is some markdown\n" +
 				"[embedmd]:# (https://fakeurl.com\\main.go)\n" +
 				"Yay!\n",
-			err: "2: could not read https://fakeurl.com\\main.go: parse https://fakeurl.com\\main.go: invalid character \"\\\\\" in host name",
+			err: "2: could not read https://fakeurl.com\\main.go: parse \"https://fakeurl.com\\\\main.go\": invalid character \"\\\\\" in host name",
 		},
 		{
 			name: "ignore commands in code blocks",

--- a/embedmd/parser.go
+++ b/embedmd/parser.go
@@ -69,6 +69,8 @@ func parsingText(out io.Writer, s textScanner, run commandRunner) (state, error)
 		return parsingCmd, nil
 	case strings.HasPrefix(line, "```"):
 		return codeParser{print: true}.parse, nil
+	case strings.HasPrefix(line, "<!-- embedmd"):
+		return codeParser{print: true}.parse, nil
 	default:
 		fmt.Fprintln(out, s.Text())
 		return parsingText, nil
@@ -89,7 +91,7 @@ func parsingCmd(out io.Writer, s textScanner, run commandRunner) (state, error) 
 	if !s.Scan() {
 		return nil, nil // end of file, which is fine.
 	}
-	if strings.HasPrefix(s.Text(), "```") {
+	if strings.HasPrefix(s.Text(), "```") || strings.HasPrefix(s.Text(), "<!-- embedmd") {
 		return codeParser{print: false}.parse, nil
 	}
 	fmt.Fprintln(out, s.Text())
@@ -105,7 +107,7 @@ func (c codeParser) parse(out io.Writer, s textScanner, run commandRunner) (stat
 	if !s.Scan() {
 		return nil, fmt.Errorf("unbalanced code section")
 	}
-	if !strings.HasPrefix(s.Text(), "```") {
+	if !strings.HasPrefix(s.Text(), "```") && !strings.HasPrefix(s.Text(), "<!-- embedmd") {
 		return c.parse, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/campoy/embedmd
+module github.com/seanblong/embedmd
+
+go 1.21.6
 
 require github.com/pmezard/go-difflib v1.0.0

--- a/main.go
+++ b/main.go
@@ -24,12 +24,15 @@
 //
 // embedmd supports two flags:
 // -d: will print the difference of the input file with what the output
-//     would have been if executed.
+//
+//	would have been if executed.
+//
 // -w: rewrites the given files rather than writing the output to the standard
-//     output.
+//
+//	output.
 //
 // For more information on the format of the commands, read the documentation
-// of the github.com/campoy/embedmd/embedmd package.
+// of the github.com/seanblong/embedmd/embedmd package.
 package main
 
 import (
@@ -41,12 +44,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/campoy/embedmd/embedmd"
 	"github.com/pmezard/go-difflib/difflib"
+	"github.com/seanblong/embedmd/embedmd"
 )
 
 // modified while building by -ldflags.
-var version = "unkown"
+var version = "unknown"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "usage: embedmd [flags] [path ...]\n")

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,3 +1,3 @@
 # embedmd releases
 
-You can find all the previously released versions in https://github.com/campoy/embedmd/releases.
+You can find all the previously released versions in https://github.com/seanblong/embedmd/releases.

--- a/releases/release.sh
+++ b/releases/release.sh
@@ -19,7 +19,7 @@ for goos in "${GOOSS[@]}"; do
         echo "\n\nbuilding $goos $goarch"
         mkdir embedmd
         pushd embedmd
-        GOOS=$goos GOARCH=$goarch go build -ldflags "-X main.version=$TAG" github.com/campoy/embedmd
+        GOOS=$goos GOARCH=$goarch go build -ldflags "-X main.version=$TAG" github.com/seanblong/embedmd
         popd
         tar -cvzf "downloads/$TAG/embedmd.$TAG.$goos.$goarch.tar.gz" embedmd
         rm -rf embedmd

--- a/sample/docs.md
+++ b/sample/docs.md
@@ -20,6 +20,10 @@ You can also see how to get the current time:
 
 [embedmd]:# (hello.go /time\.[^)]*\)/)
 
+You can also skip the fencing and add content directly into your markdown.
+
+[embedmd]:# (hello.go none /Copyright/ /reserved/)
+
 You can also have some extra code independent from `embedmd`
 
 ```python


### PR DESCRIPTION
## Description

We'd like to compose a Markdown file out of reusable smaller markdown files.  To ensure proper rendering we'll typically want to render these directly and not enclose them in fences.

For example,

📄 _component.md_

```md
## Foo

Short description of component Foo.

## How to Use

Add instructions here
```

📄 _main.md_

```md
# Main

We will use component Foo.

[embedmd]:# (component.md)
```

Right now this would render like this:

> # Main
>
> We will use component Foo.
>
>[embedmd]:# (file.md)
> ```md
> ## Foo
>
> Short description of component Foo.
>
> ## How to Use
> 
> Add instructions here
> ```

While this behavior can often be desired, we'll want to support the use case of embedding directly, without fencing, by explicitly disabling the code fence by specifying "none" as the language, e.g. `[embedmd]:# (component.md none)` which would render like so:

> # Main
>
> We will use component Foo.
>
>[embedmd]:# (file.md)
>
> ## Foo
>
> Short description of component Foo.
>
> ## How to Use
> 
> Add instructions here
>

