### PR TITLE
ci: workflow to generate releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: Generate Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Generate Release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Next Version
+        uses: reecetech/version-increment@2024.10.1
+        id: version
+        with:
+          scheme: conventional_commits
+
+      - name: Create Tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag ${{ steps.version.outputs.v-version }}
+          git push origin ${{ steps.version.outputs.v-version }}
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.v-version }}" --generate-notes
+
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build Assets
+        working-directory: releases
+        run: |
+          ./release.sh
+
+      - name: Attach Assets
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: "./releases/downloads/${{ steps.version.outputs.v-version }}/*.tar.gz"
+          release-tag: "${{ steps.version.outputs.v-version }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Generate Code Coverage Badge
+name: CI
 
 on:
   pull_request:
@@ -32,6 +32,7 @@ jobs:
         uses: tj-actions/coverage-badge-go@v2
         with:
           filename: coverage.out
+          link: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/test.yml
 
       - name: Verify Changed files
         uses: tj-actions/verify-changed-files@v16

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Update Coverage Badge
     steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/pr-conventional-commits@1.4.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -34,13 +38,13 @@ jobs:
           filename: coverage.out
           link: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/test.yml
 
-      - name: Verify Changed files
+      - name: Verify Changed Files
         uses: tj-actions/verify-changed-files@v16
         id: verify-changed-files
         with:
           files: README.md
 
-      - name: Commit changes
+      - name: Commit Changes
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: |
           git config --local user.email "action@github.com"
@@ -48,7 +52,7 @@ jobs:
           git add README.md
           git commit -m "chore: Updated coverage badge."
 
-      - name: Push changes
+      - name: Push Changes
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         uses: ad-m/github-push-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.test
 embed
 .DS_Store
+
+# ignore builds
+**/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # embedmd
 
-![Coverage](https://img.shields.io/badge/Coverage-80.2%25-brightgreen)
+[![Coverage](https://img.shields.io/badge/Coverage-78.9%25-brightgreen)](https://github.com/seanblong/embedmd/actions/workflows/test.yml)
 ![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/embedmd)](https://goreportcard.com/report/github.com/seanblong/embedmd)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/embedmd/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/embedmd/main)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # embedmd
-![Coverage](https://img.shields.io/badge/Coverage-81.9%25-brightgreen)
 
+![Coverage](https://img.shields.io/badge/Coverage-81.9%25-brightgreen)
+![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/embedmd)](https://goreportcard.com/report/github.com/seanblong/embedmd)
 
 Are you tired of copy pasting your code into your `README.md` file, just to

--- a/embedmd/content.go
+++ b/embedmd/content.go
@@ -15,8 +15,9 @@ package embedmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -36,7 +37,7 @@ type fetcher struct{}
 func (fetcher) Fetch(dir, path string) ([]byte, error) {
 	if !strings.HasPrefix(path, "http://") && !strings.HasPrefix(path, "https://") {
 		path = filepath.Join(dir, filepath.FromSlash(path))
-		return ioutil.ReadFile(path)
+		return os.ReadFile(path)
 	}
 
 	res, err := http.Get(path)
@@ -47,5 +48,5 @@ func (fetcher) Fetch(dir, path string) ([]byte, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status %s", res.Status)
 	}
-	return ioutil.ReadAll(res.Body)
+	return io.ReadAll(res.Body)
 }

--- a/embedmd/embedmd.go
+++ b/embedmd/embedmd.go
@@ -106,12 +106,18 @@ func (e *embedder) runCommand(w io.Writer, cmd *command) error {
 	if cmd.useFence {
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "```"+cmd.lang)
-		w.Write(b)
+		_, err = w.Write(b)
+		if err != nil {
+			return fmt.Errorf("could not write content to output: %w", err)
+		}
 		fmt.Fprintln(w, "```")
 	} else {
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "<!-- embedmd block start -->")
-		w.Write(b)
+		_, err = w.Write(b)
+		if err != nil {
+			return fmt.Errorf("could not write content to output: %w", err)
+		}
 		fmt.Fprintln(w, "<!-- embedmd block end -->")
 	}
 	return nil

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -13,7 +13,7 @@ func TestIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not process file (%v): %s", err, got)
 	}
-	wants, err := ioutil.ReadFile(filepath.Join("sample", "result.md"))
+	wants, err := os.ReadFile(filepath.Join("sample", "result.md"))
 	if err != nil {
 		t.Fatalf("could not read result: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -40,7 +40,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -135,7 +134,7 @@ func readFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func processFile(path string, rewrite, doDiff bool) (foundDiff bool, err error) {
@@ -175,7 +174,11 @@ func processFile(path string, rewrite, doDiff bool) (foundDiff bool, err error) 
 		return false, f.Truncate(int64(n))
 	}
 
-	io.Copy(stdout, buf)
+	_, err = io.Copy(stdout, buf)
+	if err != nil {
+		return false, fmt.Errorf("could not write to stdout: %v", err)
+	}
+
 	return false, nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -146,14 +145,5 @@ func (f *fakeFile) WriteAt(b []byte, offset int64) (int, error) { return f.buf.W
 func (f *fakeFile) Truncate(int64) error                        { return nil }
 
 func newFakeFile(s string) *fakeFile {
-	return &fakeFile{ReadCloser: ioutil.NopCloser(strings.NewReader(s))}
-}
-
-func newOpenFunc(files map[string]string) func(string) (file, error) {
-	return func(path string) (file, error) {
-		if s, ok := files[path]; ok {
-			return newFakeFile(s), nil
-		}
-		return nil, os.ErrNotExist
-	}
+	return &fakeFile{ReadCloser: io.NopCloser(strings.NewReader(s))}
 }


### PR DESCRIPTION
## Description

This PR perhaps should have been split between a `chore` and a `ci` but for time I've combined.  The main purpose of this PR is to introduce a new workflow that will automatically create releases based on conventional commit PR titles and attached the built artifacts to these releases.

## Change Log

* Add new workflow to generate releases
* Minor cleanup based on `go` linting tools:
  - Replace `ioutil` with `io` or `os` libraries as appropriate
  - Removed unused `newOpenFunc`
  - Add error checking
* Add link to CI badge workflow
* Add entry to ignore built `tar.gz` files in `gitignore`