### PR TITLE
docs: add link to ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # embedmd
 
 [![Coverage](https://img.shields.io/badge/Coverage-86.3%25-brightgreen)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
-![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)
+[![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/embedmd)](https://goreportcard.com/report/github.com/seanblong/embedmd)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/embedmd/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/embedmd/main)
 


### PR DESCRIPTION
# embedmd PR

## Description

Adding link to the CI workflow when clicked.

## Type of Change

- [ ] Feature (feat)
- [ ] Fix (fix)
- [X] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [ ] Test (test)
- [ ] Continuous Integration (ci)

## Testing

Execute `pre-commit` locally.  Nothing flagged on the updated markdown.

## Additional Information

N/A

## Checklist

- [x] My code adheres to the coding and [style guidelines][1] of the project.
- [x] My PR title follows the [conventional commit][2] format.
- [x] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [x] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title

[//]: # (H/T to https://github.com/pieterherman-dev/PR-Template-Guide/tree/main
for the template)
