### PR TITLE
feat: add support for authenticated URLs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,30 +20,13 @@ linters:
     - dupl
     - gofmt
     - misspell
-
-  # Enable presets.
-  # https://golangci-lint.run/usage/linters
-  # Default: []
-  presets:
-    - bugs
-    - comment
-    - complexity
-    - error
-    - format
-    - import
-    - metalinter
-    - module
-    - performance
-    - sql
-    - style
-    - test
-    - unused
+    - gocritic
 
 linters-settings:
   cyclop:
     # The maximal code complexity to report.
     # Default: 10
-    # max-complexity: 10
+    max-complexity: 20
     # The maximal average package complexity.
     # If it's higher than 0.0 (float) the check is enabled
     # Default: 0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,6 @@ repos:
     rev: v1.62.2
     hooks:
       - id: golangci-lint
-        additional_dependencies:
-         - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
   - repo: https://github.com/markdownlint/markdownlint
     rev: v0.13.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,13 @@ If the `GOPATH` is not part of your `PATH`, you may need to add it:
 export PATH=$(go env GOPATH)/bin:$PATH
 ```
 
+Some predefined linters have been setup in `.golangci.yaml` already and can be
+executed with the following command:
+
+```bash
+golangci-lint run
+```
+
 ##### Ruby
 
 The `markdownlint` pre-commit hook requires `ruby` of version 2.7 or later.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ If the `pathOrURL` is a URL the tool will fetch the content in that URL.
 The embedded content starts at the first line that matches `/start regexp/`
 and finishes at the first line matching `/end regexp/`.
 
+> [!TIP]
+> If the URL is part of a private repository, you can use a personal access token
+> to authenticate by saving the token to environment variable `GITHUB_TOKEN`.
+
 Omitting the the second regular expression will embed only the piece of text
 that matches `/regexp/`:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # embedmd
 
-[![Coverage](https://img.shields.io/badge/Coverage-86.3%25-brightgreen)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-86.4%25-brightgreen)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/embedmd)](https://goreportcard.com/report/github.com/seanblong/embedmd)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/embedmd/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/embedmd/main)

--- a/embedmd/content_test.go
+++ b/embedmd/content_test.go
@@ -1,4 +1,3 @@
-// content_test.go
 package embedmd
 
 import (

--- a/embedmd/content_test.go
+++ b/embedmd/content_test.go
@@ -1,3 +1,4 @@
+// content_test.go
 package embedmd
 
 import (
@@ -15,15 +16,15 @@ import (
 
 // TestFetcher_LocalFiles tests the Fetch method for local file scenarios.
 func TestFetcher_LocalFiles(t *testing.T) {
-	// Initialize the fetcher
-	var f Fetcher = fetcher{}
-
 	// Create a temporary directory for local file tests
 	tempDir, err := os.MkdirTemp("", "fetcher_test_local")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir) // Clean up
+
+	// Initialize the fetcher with default client
+	f := NewFetcher(nil)
 
 	// Define table of local file test cases
 	localTests := []struct {
@@ -87,7 +88,7 @@ func TestFetcher_LocalFiles(t *testing.T) {
 						t.Errorf("Unexpected error: %v", err)
 					}
 					if !bytes.Equal(data, tt.expected) {
-						t.Errorf("Expected '%s', got '%s'", string(tt.expected), string(data))
+						t.Errorf("Expected '%s', got '%s'", string(tt.expected), data)
 					}
 				}
 			} else {
@@ -102,7 +103,7 @@ func TestFetcher_LocalFiles(t *testing.T) {
 						t.Errorf("Unexpected error: %v", err)
 					}
 					if !bytes.Equal(data, tt.expected) {
-						t.Errorf("Expected '%s', got '%s'", string(tt.expected), string(data))
+						t.Errorf("Expected '%s', got '%s'", string(tt.expected), data)
 					}
 				}
 			}
@@ -112,9 +113,6 @@ func TestFetcher_LocalFiles(t *testing.T) {
 
 // TestFetcher_URLs tests the Fetch method for URL scenarios.
 func TestFetcher_URLs(t *testing.T) {
-	// Initialize the fetcher
-	var f Fetcher = fetcher{}
-
 	// Define table of URL test cases
 	urlTests := []struct {
 		name          string
@@ -122,7 +120,7 @@ func TestFetcher_URLs(t *testing.T) {
 		expectError   bool
 		expected      []byte
 		errorContains string
-		customClient  func()
+		customClient  func(t *testing.T) *http.Client
 	}{
 		{
 			name: "fetch_valid_url",
@@ -213,15 +211,12 @@ func TestFetcher_URLs(t *testing.T) {
 			expectError:   true,
 			expected:      nil,
 			errorContains: "timeout",
-			customClient: func() {
-				// Override the HTTP client with a timeout
-				originalClient := http.DefaultClient
-				http.DefaultClient = &http.Client{
+			customClient: func(_ *testing.T) *http.Client {
+				// Create a client with a short timeout
+				client := &http.Client{
 					Timeout: 1 * time.Nanosecond, // Force timeout
 				}
-				// Restore the original client after the test
-				// Note: `t.Cleanup` ensures this runs even if the test fails
-				t.Cleanup(func() { http.DefaultClient = originalClient })
+				return client
 			},
 		},
 	}
@@ -231,12 +226,16 @@ func TestFetcher_URLs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			url := tt.setup(t)
 
-			// Apply any custom client settings
+			// Instantiate the fetcher with a custom client if provided
+			var fetcherInstance Fetcher
 			if tt.customClient != nil {
-				tt.customClient()
+				client := tt.customClient(t)
+				fetcherInstance = NewFetcher(client)
+			} else {
+				fetcherInstance = NewFetcher(nil)
 			}
 
-			data, err := f.Fetch("", url)
+			data, err := fetcherInstance.Fetch("", url)
 
 			if tt.expectError {
 				if err == nil {
@@ -249,9 +248,75 @@ func TestFetcher_URLs(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if !bytes.Equal(data, tt.expected) {
-					t.Errorf("Expected '%s', got '%s'", string(tt.expected), string(data))
+					t.Errorf("Expected '%s', got '%s'", string(tt.expected), data)
 				}
 			}
 		})
+	}
+}
+
+// TestFetcher_AuthHeader tests that the Authorization header is correctly set when GITHUB_TOKEN is present.
+func TestFetcher_AuthHeader(t *testing.T) {
+	expectedContent := "Authorized Content"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		token, exists := os.LookupEnv("GITHUB_TOKEN")
+		if exists {
+			expectedAuth := fmt.Sprintf("Bearer %s", token)
+			if authHeader != expectedAuth {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		} else if authHeader != "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(expectedContent))
+	}))
+	defer server.Close()
+
+	// Set the GITHUB_TOKEN environment variable
+	os.Setenv("GITHUB_TOKEN", "testtoken")
+	defer os.Unsetenv("GITHUB_TOKEN")
+
+	// Initialize the fetcher with default client
+	f := NewFetcher(nil)
+
+	data, err := f.Fetch("", server.URL)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !bytes.Equal(data, []byte(expectedContent)) {
+		t.Errorf("Expected '%s', got '%s'", expectedContent, data)
+	}
+}
+
+// TestFetcher_NoAuthHeader ensures that no Authorization header is set when GITHUB_TOKEN is absent.
+func TestFetcher_NoAuthHeader(t *testing.T) {
+	expectedContent := "No Auth Content"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(expectedContent))
+	}))
+	defer server.Close()
+
+	// Ensure GITHUB_TOKEN is not set
+	os.Unsetenv("GITHUB_TOKEN")
+
+	// Initialize the fetcher with default client
+	f := NewFetcher(nil)
+
+	data, err := f.Fetch("", server.URL)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !bytes.Equal(data, []byte(expectedContent)) {
+		t.Errorf("Expected '%s', got '%s'", expectedContent, data)
 	}
 }

--- a/embedmd/embedmd.go
+++ b/embedmd/embedmd.go
@@ -61,7 +61,7 @@ import (
 // command. When a command is found, it is executed and the output is written
 // into the given io.Writer with the rest of standard markdown.
 func Process(out io.Writer, in io.Reader, opts ...Option) error {
-	e := embedder{Fetcher: fetcher{}}
+	e := embedder{Fetcher: NewFetcher(nil)}
 	for _, opt := range opts {
 		opt.f(&e)
 	}


### PR DESCRIPTION
# embedmd PR

## Description

Adding support for private Github repositories where an environment variable, `GITHUB_TOKEN`, will be used as an `Authorization: bearer` token if set.  This can be expanded in the future to use deploy keys and other mechanisms for authentication.

## Type of Change

- [X] Feature (feat)
- [ ] Fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [ ] Test (test)
- [ ] Continuous Integration (ci)

## Testing

Additional test functions have been added:

- `TestFetcher_AuthHeader`
- `TestFetcher_NoAuthHeader`

## Additional Information

I've modified the `golangci` utility and `pre-commit-config.yaml` upon further testing with this change.  They were helpful in identifying common problems in `go` code.

## Checklist

- [x] My code adheres to the coding and [style guidelines][1] of the project.
- [x] My PR title follows the [conventional commit][2] format.
- [x] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [x] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title

[//]: # (H/T to https://github.com/pieterherman-dev/PR-Template-Guide/tree/main
for the template)
