### PR TITLE
ci: allow generate release to write content

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: Generate Release
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:


### PR DESCRIPTION
# embedmd PR

## Description

Fixing a bad permission setting.  This should allow the `Generate Release` workflow to push tags to the repository.

## Type of Change

- [ ] Feature (feat)
- [ ] Fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [ ] Test (test)
- [X] Continuous Integration (ci)

## Testing

N/A (🚀)

## Additional Information

N/A

## Checklist

- [X] My code adheres to the coding and [style guidelines][1] of the project.
- [X] My PR title follows the [conventional commit][2] format.
- [X] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [ ] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title

[//]: # (H/T to https://github.com/pieterherman-dev/PR-Template-Guide/tree/main
for the template)
