### PR TITLE
fix: bug where a nested fence within markdown using "none" section breaks rendering and repeats output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # embedmd
 
-[![Coverage](https://img.shields.io/badge/Coverage-86.4%25-brightgreen)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
+[![Coverage](https://img.shields.io/badge/Coverage-87.1%25-brightgreen)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
 [![CI](https://github.com/seanblong/embedmd/actions/workflows/test.yaml/badge.svg)](https://github.com/seanblong/embedmd/actions/workflows/test.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/seanblong/embedmd)](https://goreportcard.com/report/github.com/seanblong/embedmd)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/seanblong/embedmd/main.svg)](https://results.pre-commit.ci/latest/github/seanblong/embedmd/main)

--- a/embedmd/embedmd_test.go
+++ b/embedmd/embedmd_test.go
@@ -33,6 +33,19 @@ func main() {
 }
 `
 
+const markdownContent = `
+# Markdown Content
+
+` + "```go" + `
+package main
+
+import "fmt"
+
+func main() {
+        fmt.Println("hello, test")
+}
+` + "```"
+
 func TestExtract(t *testing.T) {
 	tc := []struct {
 		name       string
@@ -351,6 +364,108 @@ func TestProcess(t *testing.T) {
 				"```markdown\n" +
 				"[embedmd]:# (nothing.md)\n" +
 				"```\n" +
+				"Yay!\n",
+		},
+		{
+			name: "new nested code block in none block",
+			in: "[embedmd]:# (code.md none)\n" +
+				"Yay!\n",
+			files: map[string][]byte{"code.md": []byte(markdownContent)},
+			out: "[embedmd]:# (code.md none)\n\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+		},
+		{
+			name: "replace existing nested code block in none block",
+			in: "[embedmd]:# (code.md none)\n\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+			files: map[string][]byte{"code.md": []byte(markdownContent)},
+			out: "[embedmd]:# (code.md none)\n\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+		},
+		{
+			name: "replace existing nested code block in none block (missing new line)",
+			in: "[embedmd]:# (code.md none)\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+			files: map[string][]byte{"code.md": []byte(markdownContent)},
+			out: "[embedmd]:# (code.md none)\n\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n" +
+				"Yay!\n",
+		},
+		{
+			name: "replace existing nested code block in none block (errant string",
+			in: "[embedmd]:# (code.md none)\n" +
+				"Yay!\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n",
+			files: map[string][]byte{"code.md": []byte(markdownContent)},
+			out: "[embedmd]:# (code.md none)\n\n" +
+				"<!-- embedmd block start -->\n\n" +
+				"# Markdown Content\n\n" +
+				"```go\n" +
+				"package main\n\n" +
+				"import \"fmt\"\n\n" +
+				"func main() {\n" +
+				"        fmt.Println(\"hello, test\")\n" +
+				"}\n" +
+				"```\n" +
+				"<!-- embedmd block end -->\n" +
 				"Yay!\n",
 		},
 	}

--- a/embedmd/parser_test.go
+++ b/embedmd/parser_test.go
@@ -88,6 +88,16 @@ func TestParser(t *testing.T) {
 			in:   "```go\nhello\n```\n\n```go\nbye\n```\n",
 			out:  "```go\nhello\n```\n\n```go\nbye\n```\n",
 		},
+		{
+			name: "embedded code sections",
+			in:   "```go\nhello\n\n```go\nbye\n```\n```\n",
+			out:  "```go\nhello\n\n```go\nbye\n```\n```\n",
+		},
+		{
+			name: "embedded code in none section",
+			in:   "<!-- embedmd block start -->\n```go\nhello\n<!-- embedmd block end -->\n",
+			out:  "<!-- embedmd block start -->\n```go\nhello\n<!-- embedmd block end -->\n",
+		},
 	}
 
 	for _, tt := range tc {


### PR DESCRIPTION
# embedmd PR

## Description

I discovered this bug when attempting to render Markdown with the `none` language flag, e.g.,

_content.md_

```Markdown

# This is code content

```go
package main

import "fmt"

func main() {
        fmt.Println("hello, test")
}
\```
```

Then rendering it like so:

`[embedmd]:# (./content.md none)`

The use case of the `none` flag is to compile larger Markdown documents, fully rendered, out of smaller, composite parts.  There's an argument to made that the code itself should be referenced in the main markdown, or a link to the `content.md` document, but I still think there are valid use cases where we may want to render complex existing markdowns.

## Type of Change

- [ ] Feature (feat)
- [X] Fix (fix)
- [ ] Documentation (docs)
- [ ] Refactoring (refactor)
- [ ] Reverting change (revert)
- [ ] Performance improvement (perf)
- [ ] Chore (chore)
- [ ] Test (test)
- [ ] Continuous Integration (ci)

## Testing

See the "nested code block in none" block.  These three cases failed pre-change and function post-change, e.g.,

```go
name: "new nested code block in none block",
in: "[embedmd]:# (code.md none)\n" +
	"Yay!\n",
files: map[string][]byte{"code.md": []byte(markdownContent)},
out: "[embedmd]:# (code.md none)\n\n" +
	"<!-- embedmd block start -->\n\n" +
	"# Markdown Content\n\n" +
	"```go\n" +
	"package main\n\n" +
	"import \"fmt\"\n\n" +
	"func main() {\n" +
	"        fmt.Println(\"hello, test\")\n" +
	"}\n" +
	"```\n" +
	"<!-- embedmd block end -->\n" +
	"Yay!\n",
```

```console
expected output:
###
[embedmd]:# (code.md none)

<!-- embedmd block start -->

# Markdown Content

```go
package main

import "fmt"

func main() {
        fmt.Println("hello, test")
}
```
<!-- embedmd block end -->
Yay!

###; got###
[embedmd]:# (code.md none)

<!-- embedmd block start -->

# Markdown Content

```go
package main

import "fmt"

func main() {
        fmt.Println("hello, test")
}
```
<!-- embedmd block end -->
package main

import "fmt"

func main() {
        fmt.Println("hello, test")
}
```
<!-- embedmd block end -->
Yay!

###
```

## Additional Information

I've added some additional tests to `parser_test.go`.  These functioned as expected both pre and post change, but still felt like potential edge cases worthy of checking.

## Checklist

- [X] My code adheres to the coding and [style guidelines][1] of the project.
- [X] My PR title follows the [conventional commit][2] format.
- [X] I have made corresponding changes to the documentation, e.g., comments, READMEs
- [X] My changes generate no new errors/warnings

<!-- links -->
[1]: ../CONTRIBUTING.md
[2]: ../CONTRIBUTING.md#pr-title

[//]: # (H/T to https://github.com/pieterherman-dev/PR-Template-Guide/tree/main
for the template)
